### PR TITLE
Install riscv-tests as a submodule and let it possible to be built with CMake.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ext/riscv-tests/riscv-tests"]
+	path = ext/riscv-tests/riscv-tests
+	url = https://github.com/riscv-software-src/riscv-tests.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,3 +10,4 @@ set(CMAKE_EXE_LINKER_FLAGS "-fuse-ld=mold")
 set(CMAKE_CXX_COMPILER_LAUNCHER ccache)
 
 add_subdirectory(test)
+add_subdirectory(ext)

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ FROM amd64/ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+WORKDIR /root
+
+# Verilator
+
 RUN apt update
 RUN apt install -y git help2man perl python3 make
 RUN apt install -y clang-19 libc++-19-dev libc++abi-19-dev
@@ -10,13 +14,29 @@ RUN apt install -y ccache mold libgoogle-perftools-dev numactl
 RUN apt install -y autoconf flex bison
 RUN apt install -y cmake ninja-build
 
-WORKDIR /root
-
 RUN git clone https://github.com/verilator/verilator
 RUN cd verilator && \
     git pull && \
     git checkout v5.030 && \
     autoconf && \
     CC=clang-19 CXX=clang++-19 ./configure && \
-    make -j$(((nproc)/2+1)) && \
+    make -j`nproc` && \
     make install
+
+# riscv-gnu-toolchain
+
+RUN apt install -y automake autotools-dev curl python3-pip python3-tomli \
+    libmpc-dev libmpfr-dev libgmp-dev gawk build-essential texinfo \
+    gperf libtool patchutils bc libexpat-dev libglib2.0-dev libslirp-dev
+
+ENV ARCH=rv32ima_zicsr_zifencei_zicntr
+ENV RISCV=/opt/${ARCH}
+
+RUN git clone https://github.com/riscv/riscv-gnu-toolchain
+RUN cd riscv-gnu-toolchain && \
+    git pull && \
+    git checkout 2025.05.01 && \
+    ./configure --prefix=${RISCV} --with-arch=${ARCH} --with-abi=ilp32 && \
+    make -j`nproc`
+
+ENV PATH=$PATH:${RISCV}/bin

--- a/README.md
+++ b/README.md
@@ -57,11 +57,13 @@ sudo sh get-docker.sh
 
 ## Getting started
 
-Clone the repository and enther the directory.
+Clone the repository **recursively** and enther the directory.
+Don't forget `--recursive`!!!!
 
 ```bash
-git clone git@github.com:offnaria/offnariscv.git
+git clone --recursive git@github.com:offnaria/offnariscv.git # Don't forget --recursive!!!!
 cd offnariscv
+# git submodule update --init --recursive # Do this, if you forgot --recursive at cloning the repo.
 ```
 
 Set up the Docker container.

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MIT
+
+add_subdirectory(riscv-tests)

--- a/ext/riscv-tests/CMakeLists.txt
+++ b/ext/riscv-tests/CMakeLists.txt
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: MIT
+
+add_custom_target(riscv-tests-isa ALL WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/riscv-tests
+  COMMAND autoconf
+  COMMAND CC=riscv32-unknown-elf-gcc ./configure --with-xlen=32
+  COMMAND make -j`nproc` isa
+  COMMAND install -p -m 644 -D -t ${CMAKE_BINARY_DIR}/riscv-tests/riscv-tests/isa `find isa -maxdepth 1 -type f`
+  COMMENT "Building riscv-tests/isa")
+
+add_custom_target(riscv-tests-clean WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/riscv-tests
+  COMMAND make clean
+  COMMENT "Cleaning riscv-tests/isa")


### PR DESCRIPTION
By typing `ninja` in `build` directory, [riscv-tests](https://github.com/riscv-software-src/riscv-tests)'s ISA tests will be built and copied into `build/ext/riscv-tests/riscv-tests/isa/`.